### PR TITLE
fix: state is null

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,7 +51,7 @@ export default function Home({
       <main className={inter.className}>
         <Header />
 
-        {state === undefined ? (
+        {state == undefined ? (
           <Center>
             <Text fw={700}>
               Monitor State is not defined now, please check your worker&apos;s status and KV


### PR DESCRIPTION
This pull request includes a minor change to the `pages/index.tsx` file. The change modifies a strict equality check (`===`) to a loose equality check (`==`) when comparing the `state` variable to `undefined`.

* [`pages/index.tsx`](diffhunk://#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3L54-R54): Changed the equality operator from `===` to `==` in the conditional rendering of the `state` variable.

<img width="561" alt="image" src="https://github.com/user-attachments/assets/93b84908-d035-442b-ad85-0183bbdd6b3f" />
