### PR TITLE
Detailed Monitor Pages

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@ import { Container, Group, Text } from '@mantine/core'
 import classes from '@/styles/Header.module.css'
 import { pageConfig } from '@/uptime.config'
 import { PageConfigLink } from '@/types/config'
+import Link from 'next/link'
 
 export default function Header() {
   const linkToElement = (link: PageConfigLink) => {
@@ -22,20 +23,16 @@ export default function Header() {
     <header className={classes.header}>
       <Container size="md" className={classes.inner}>
         <div>
-          <a href="https://github.com/lyc8503/UptimeFlare" target="_blank">
-            <Text size="xl" span>
-              🕒
-            </Text>
+          <Link href="/">
             <Text
               size="xl"
-              span
               fw={700}
               variant="gradient"
               gradient={{ from: 'blue', to: 'cyan', deg: 90 }}
             >
-              UptimeFlare
+              {pageConfig.title || 'UptimeFlare'}
             </Text>
-          </a>
+          </Link>
         </div>
 
         <Group gap={5} visibleFrom="sm">

--- a/components/IncidentList.tsx
+++ b/components/IncidentList.tsx
@@ -1,0 +1,57 @@
+import { Card, Text, Grid, Flex, Badge } from '@mantine/core'
+import { formatDistance } from 'date-fns'
+
+export default function IncidentList({
+  incidents,
+}: {
+  incidents: { start: number[]; end: number | undefined; error: string[] }[]
+}) {
+  if (!incidents || incidents.length === 0) {
+    return <Text mt="md">No historical incidents found.</Text>
+  }
+
+  return (
+    <Grid mt="md">
+      {[...incidents].reverse().map((incident, index) => (
+        <Grid.Col key={index} span={12}>
+          <Card withBorder padding="md">
+            <Flex justify="space-between">
+              <div>
+                <Text fw={700}>{incident.error[0]}</Text>
+              </div>
+
+              <div>
+                <Badge color={incident.end ? 'gray' : 'red'} variant="outline">
+                  {incident.end ? 'Resolved' : 'Ongoing'}
+                </Badge>
+              </div>
+            </Flex>
+
+            <Flex gap="md" mt="sm">
+              <div>
+                <Text size="sm" c="dimmed">
+                  Start:{' '}
+                  {formatDistance(new Date(incident.start[0] * 1000), new Date(), {
+                    addSuffix: true,
+                  })}
+                </Text>
+              </div>
+
+              {incident.end && (
+                <div>
+                  <Text size="sm" c="dimmed">
+                    Duration:{' '}
+                    {formatDistance(
+                      new Date(incident.start[0] * 1000),
+                      new Date(incident.end * 1000)
+                    )}
+                  </Text>
+                </div>
+              )}
+            </Flex>
+          </Card>
+        </Grid.Col>
+      ))}
+    </Grid>
+  )
+}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,49 @@
+import Head from 'next/head'
+import { Inter } from 'next/font/google'
+import Header from './Header'
+import { Container, Divider, Text } from '@mantine/core'
+import { pageConfig } from '@/uptime.config'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Head>
+        <title>{pageConfig.title}</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <main className={inter.className}>
+        <Header />
+        <Container size="md" mt="xl">
+          {children}
+        </Container>
+
+        <Divider mt="lg" />
+        <Text
+          size="xs"
+          mt="xs"
+          mb="xs"
+          style={{
+            textAlign: 'center',
+          }}
+          className="footer"
+        >
+          Open-source monitoring and status page powered by{' '}
+          <a href="https://github.com/lyc8503/UptimeFlare" target="_blank">
+            Uptimeflare
+          </a>{' '}
+          and{' '}
+          <a href="https://www.cloudflare.com/" target="_blank">
+            Cloudflare
+          </a>
+          , made with ❤ by{' '}
+          <a href="https://github.com/lyc8503" target="_blank">
+            lyc8503
+          </a>
+          .
+        </Text>
+      </main>
+    </>
+  )
+}

--- a/components/MonitorDetail.tsx
+++ b/components/MonitorDetail.tsx
@@ -5,13 +5,16 @@ import DetailChart from './DetailChart'
 import DetailBar from './DetailBar'
 import { getColor } from '@/util/color'
 import { maintenances } from '@/uptime.config'
+import Link from 'next/link'
 
 export default function MonitorDetail({
   monitor,
   state,
+  link,
 }: {
   monitor: MonitorTarget
   state: MonitorState
+  link?: string
 }) {
   if (!state.latency[monitor.id])
     return (
@@ -65,10 +68,10 @@ export default function MonitorDetail({
   // Conditionally render monitor name with or without hyperlink based on monitor.url presence
   const monitorNameElement = (
     <Text mt="sm" fw={700} style={{ display: 'inline-flex', alignItems: 'center' }}>
-      {monitor.statusPageLink ? (
+      {link ? (
         <a
-          href={monitor.statusPageLink}
-          target="_blank"
+          href={link}
+          target={link.startsWith('/') ? '_self' : '_blank'}
           style={{ display: 'inline-flex', alignItems: 'center', color: 'inherit' }}
         >
           {statusIcon} {monitor.name}

--- a/components/MonitorList.tsx
+++ b/components/MonitorList.tsx
@@ -76,7 +76,11 @@ export default function MonitorList({
                 .map((monitor) => (
                   <div key={monitor.id}>
                     <Card.Section ml="xs" mr="xs">
-                      <MonitorDetail monitor={monitor} state={state} />
+                      <MonitorDetail
+                        link={`/monitor/${monitor.id}`}
+                        monitor={monitor}
+                        state={state}
+                      />
                     </Card.Section>
                   </div>
                 ))}

--- a/components/OverallStatus.tsx
+++ b/components/OverallStatus.tsx
@@ -58,18 +58,19 @@ export default function OverallStatus({
   })
 
   const now = new Date()
-  let filteredMaintenances: (Omit<MaintenanceConfig, 'monitors'> & { monitors?: MonitorTarget[] })[] =
-    maintenances
-      .filter((m) => now >= new Date(m.start) && (!m.end || now <= new Date(m.end)))
-      .map((maintenance) => ({
-        ...maintenance,
-        monitors: maintenance.monitors?.map(
-          (monitorId) => monitors.find((mon) => monitorId === mon.id)!
-        ),
-      }))
+  let filteredMaintenances: (Omit<MaintenanceConfig, 'monitors'> & {
+    monitors?: MonitorTarget[]
+  })[] = maintenances
+    .filter((m) => now >= new Date(m.start) && (!m.end || now <= new Date(m.end)))
+    .map((maintenance) => ({
+      ...maintenance,
+      monitors: maintenance.monitors?.map(
+        (monitorId) => monitors.find((mon) => monitorId === mon.id)!
+      ),
+    }))
 
   return (
-    <Container size="md" mt="xl">
+    <>
       <Center>{icon}</Center>
       <Title mt="sm" style={{ textAlign: 'center' }} order={1}>
         {statusString}
@@ -88,6 +89,6 @@ export default function OverallStatus({
           style={{ maxWidth: groupedMonitor ? '897px' : '865px' }}
         />
       ))}
-    </Container>
+    </>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "date-fns": "^4.1.0",
         "eslint": "^8",
         "eslint-config-next": "^14.2.28",
         "postcss": "^8.4.31",
@@ -4362,6 +4363,16 @@
       "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -12196,6 +12207,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
       "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true
+    },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "dev": true
     },
     "debug": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "date-fns": "^4.1.0",
     "eslint": "^8",
     "eslint-config-next": "^14.2.28",
     "postcss": "^8.4.31",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,12 @@
-import Head from 'next/head'
-
 import { Inter } from 'next/font/google'
 import { MonitorState, MonitorTarget } from '@/types/config'
 import { KVNamespace } from '@cloudflare/workers-types'
-import { maintenances, pageConfig, workerConfig } from '@/uptime.config'
+import { maintenances, workerConfig } from '@/uptime.config'
 import OverallStatus from '@/components/OverallStatus'
-import Header from '@/components/Header'
 import MonitorList from '@/components/MonitorList'
-import { Center, Divider, Text } from '@mantine/core'
+import { Center, Text } from '@mantine/core'
 import MonitorDetail from '@/components/MonitorDetail'
+import Layout from '@/components/Layout'
 
 export const runtime = 'experimental-edge'
 const inter = Inter({ subsets: ['latin'] })
@@ -42,54 +40,20 @@ export default function Home({
   }
 
   return (
-    <>
-      <Head>
-        <title>{pageConfig.title}</title>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-
-      <main className={inter.className}>
-        <Header />
-
-        {state == undefined ? (
-          <Center>
-            <Text fw={700}>
-              Monitor State is not defined now, please check your worker&apos;s status and KV
-              binding!
-            </Text>
-          </Center>
-        ) : (
-          <div>
-            <OverallStatus state={state} monitors={monitors} maintenances={maintenances} />
-            <MonitorList monitors={monitors} state={state} />
-          </div>
-        )}
-
-        <Divider mt="lg" />
-        <Text
-          size="xs"
-          mt="xs"
-          mb="xs"
-          style={{
-            textAlign: 'center',
-          }}
-        >
-          Open-source monitoring and status page powered by{' '}
-          <a href="https://github.com/lyc8503/UptimeFlare" target="_blank">
-            Uptimeflare
-          </a>{' '}
-          and{' '}
-          <a href="https://www.cloudflare.com/" target="_blank">
-            Cloudflare
-          </a>
-          , made with ❤ by{' '}
-          <a href="https://github.com/lyc8503" target="_blank">
-            lyc8503
-          </a>
-          .
-        </Text>
-      </main>
-    </>
+    <Layout>
+      {state == undefined ? (
+        <Center>
+          <Text fw={700}>
+            Monitor State is not defined now, please check your worker&apos;s status and KV binding!
+          </Text>
+        </Center>
+      ) : (
+        <div>
+          <OverallStatus state={state} monitors={monitors} maintenances={maintenances} />
+          <MonitorList monitors={monitors} state={state} />
+        </div>
+      )}
+    </Layout>
   )
 }
 
@@ -106,11 +70,8 @@ export async function getServerSideProps() {
     return {
       id: monitor.id,
       name: monitor.name,
-      // @ts-ignore
       tooltip: monitor?.tooltip,
-      // @ts-ignore
       statusPageLink: monitor?.statusPageLink,
-      // @ts-ignore
       hideLatencyChart: monitor?.hideLatencyChart,
     }
   })

--- a/pages/monitor/[id].tsx
+++ b/pages/monitor/[id].tsx
@@ -1,0 +1,81 @@
+import { GetServerSideProps } from 'next'
+import { useRouter } from 'next/router'
+import { MonitorState, MonitorTarget, MaintenanceConfig } from '@/types/config'
+import { maintenances, workerConfig } from '@/uptime.config'
+import MonitorDetail from '@/components/MonitorDetail'
+import DetailChart from '@/components/DetailChart'
+import MaintenanceAlert from '@/components/MaintenanceAlert'
+import { Text, Center, Card } from '@mantine/core'
+import Layout from '@/components/Layout'
+import IncidentList from '@/components/IncidentList'
+
+export const runtime = 'experimental-edge'
+
+type Props = {
+  monitor: MonitorTarget | null
+  state: string
+  maintenance: Omit<MaintenanceConfig, 'monitors'> & { monitors?: MonitorTarget[] }
+}
+
+export default function MonitorPage({ monitor, state, maintenance }: Props) {
+  const router = useRouter()
+  const parsedState: MonitorState | null = JSON.parse(state)
+  if (router.isFallback) {
+    return <Text>Loading...</Text>
+  }
+  if (!monitor || !parsedState) {
+    return (
+      <Center>
+        <Text fw={700}>Monitor not found or state unavailable!</Text>
+      </Center>
+    )
+  }
+
+  const incidents = [...(parsedState.incident?.[monitor.id] || [])] // need to clone to not modify origin with shift below
+  if (incidents) incidents.shift() // remove dummy entry
+  return (
+    <Layout>
+      {maintenance && <MaintenanceAlert maintenance={maintenance} />}
+      <Card mt={maintenance && 'lg'}>
+        <MonitorDetail link={monitor.statusPageLink} monitor={monitor} state={parsedState} />
+      </Card>
+      {incidents.length > 0 && (
+        <Card mt="lg">
+          <IncidentList incidents={incidents} />
+        </Card>
+      )}
+    </Layout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const id = context.params!.id as string
+  const { UPTIMEFLARE_STATE } = process.env as unknown as {
+    UPTIMEFLARE_STATE: KVNamespace
+  }
+
+  const monitor = workerConfig.monitors.find((m) => m.id === id) || null
+  // Read state as string from KV, to avoid hitting server-side cpu time limit
+  const state = (await UPTIMEFLARE_STATE?.get('state')) as unknown as MonitorState
+
+  // Find maintenance for this monitor, if any
+  const maintenance =
+    maintenances
+      .filter((m) => m.monitors && m.monitors.includes(id))
+      .map((e) => {
+        return {
+          ...e,
+          monitors: e.monitors?.map((mon) =>
+            workerConfig.monitors.find((confMon) => confMon.id === mon)
+          ),
+        }
+      })[0] || null
+
+  return {
+    props: {
+      monitor,
+      state,
+      maintenance,
+    },
+  }
+}


### PR DESCRIPTION
Hello, I've been busy the last week but got around today to work on the single monitor pages. Currently it's mostly reusing existing components and I've moved some stuff around. Here is a list of the changes:

- Moved to dedicated Layout Component to not have duplicate Header/Footer Code
- Changed the Header Title to be taken from `pageConfig.pageTitle` because we need a way to get to the Homepage now
- Added a way to pass the link of a monitor to the component so we can link to the sub-page on the homepage and to the statusPageLink from the detail page.
- added an IncidentList component to display the list of incidents

A few smaller design things are (as last time) still open where I'm stuck:
- Availability-Bars are not centered on the detail page
- I would prefer for the footer to be at the bottom of the page, not sticky but at the bottom if there is not enough content
- I dont think the gradient on the title together with the underline is visually appealing, perhaps we can make it more like the buttons on the right side so it's not that prominent

This is a list of things I'm considering, but currently not planning to implement (let's discuss these):
- Disable detail-page via config parameter `disableDetailPage` or something like that.
- Limit number of incidents to show on the detail page
- The OverallStatus Component could be reused on the detail page, but imo you already have the information there so a "hey this component has problems" is not really required.
- There are some smaller nit-picks like the duplicated code in the `getServerSideProps` functions but I don't know how to unify those

My development version is deployed here: https://uptimeflar-dev.pages.dev/ so you can click around a bit. Also here are some screenshots:

![image](https://github.com/user-attachments/assets/a1999dd4-7b96-4ea4-95e8-9acfbe673386)

With active maintenance: 
![image](https://github.com/user-attachments/assets/1d0324d2-7195-4af6-bd35-21cefbc2b589)

With incident history:
![image](https://github.com/user-attachments/assets/20629f90-9f2d-48fd-a362-99f27b905100)
