### PR TITLE
feat: incident history

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,31 @@
+import { Divider, Text } from '@mantine/core'
+
+export default function Footer() {
+  return (
+    <>
+      <Divider mt="lg" />
+      <Text
+        size="xs"
+        mt="xs"
+        mb="xs"
+        style={{
+          textAlign: 'center',
+        }}
+      >
+        Open-source monitoring and status page powered by{' '}
+        <a href="https://github.com/lyc8503/UptimeFlare" target="_blank">
+          Uptimeflare
+        </a>{' '}
+        and{' '}
+        <a href="https://www.cloudflare.com/" target="_blank">
+          Cloudflare
+        </a>
+        , made with ❤ by{' '}
+        <a href="https://github.com/lyc8503" target="_blank">
+          lyc8503
+        </a>
+        .
+      </Text>
+    </>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,10 +4,10 @@ import { pageConfig } from '@/uptime.config'
 import { PageConfigLink } from '@/types/config'
 
 export default function Header() {
-  const linkToElement = (link: PageConfigLink) => {
+  const linkToElement = (link: PageConfigLink, i: number) => {
     return (
       <a
-        key={link.label}
+        key={i}
         href={link.link}
         target="_blank"
         className={classes.link}
@@ -17,6 +17,8 @@ export default function Header() {
       </a>
     )
   }
+
+  const links = [{ label: 'Incident History', link: '/incidents' }, ...(pageConfig.links || [])]
 
   return (
     <header className={classes.header}>
@@ -39,11 +41,11 @@ export default function Header() {
         </div>
 
         <Group gap={5} visibleFrom="sm">
-          {pageConfig.links?.map(linkToElement)}
+          {links?.map(linkToElement)}
         </Group>
 
         <Group gap={5} hiddenFrom="sm">
-          {pageConfig.links?.filter((link) => link.highlight).map(linkToElement)}
+          {links?.filter((link) => link.highlight).map(linkToElement)}
         </Group>
       </Container>
     </header>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,7 +9,7 @@ export default function Header() {
       <a
         key={i}
         href={link.link}
-        target="_blank"
+        target={link.link.startsWith('/') ? undefined : '_blank'}
         className={classes.link}
         data-active={link.highlight}
       >
@@ -24,7 +24,10 @@ export default function Header() {
     <header className={classes.header}>
       <Container size="md" className={classes.inner}>
         <div>
-          <a href="https://github.com/lyc8503/UptimeFlare" target="_blank">
+          <a
+            href={location.pathname == '/' ? 'https://github.com/lyc8503/UptimeFlare' : '/'}
+            target={location.pathname == '/' ? '_blank' : undefined}
+          >
             <Text size="xl" span>
               🕒
             </Text>
@@ -45,7 +48,7 @@ export default function Header() {
         </Group>
 
         <Group gap={5} hiddenFrom="sm">
-          {links?.filter((link) => link.highlight).map(linkToElement)}
+          {links?.filter((link) => (link.highlight || link.link.startsWith('/'))).map(linkToElement)}
         </Group>
       </Container>
     </header>

--- a/components/MaintenanceAlert.tsx
+++ b/components/MaintenanceAlert.tsx
@@ -5,70 +5,57 @@ import { MaintenanceConfig, MonitorTarget } from '@/types/config'
 export default function MaintenanceAlert({
   maintenance,
   style,
-  hash,
 }: {
   maintenance: Omit<MaintenanceConfig, 'monitors'> & { monitors?: MonitorTarget[] }
   style?: React.CSSProperties
-  hash?: string
 }) {
   const titleStyle: React.CSSProperties = {}
-  if (hash) {
-    titleStyle['textDecoration'] = 'underline'
-    titleStyle['cursor'] = 'pointer'
-  }
-
-  function updateHash() {
-    if (!hash) return
-    window.location.hash = hash
-  }
 
   return (
-    <div id={hash}>
-      <Alert
-        icon={<IconAlertTriangle />}
-        title={
-          (
-            <span style={titleStyle} onClick={updateHash}>
-              {maintenance.title || 'Scheduled Maintenance'}
-            </span>
-          )
-        }
-        color={maintenance.color || 'yellow'}
-        withCloseButton={false}
-        style={{ position: 'relative', margin: '16px auto 0 auto', ...style }}
+    <Alert
+      icon={<IconAlertTriangle />}
+      title={
+        (
+          <span style={titleStyle}>
+            {maintenance.title || 'Scheduled Maintenance'}
+          </span>
+        )
+      }
+      color={maintenance.color || 'yellow'}
+      withCloseButton={false}
+      style={{ position: 'relative', margin: '16px auto 0 auto', ...style }}
+    >
+      {/* Date range in top right */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 10,
+          right: 10,
+          fontSize: '0.85rem',
+          textAlign: 'right',
+          padding: '2px 8px',
+          borderRadius: 6,
+        }}
       >
-        {/* Date range in top right */}
-        <div
-          style={{
-            position: 'absolute',
-            top: 10,
-            right: 10,
-            fontSize: '0.85rem',
-            textAlign: 'right',
-            padding: '2px 8px',
-            borderRadius: 6,
-          }}
-        >
-          <b>From:</b> {new Date(maintenance.start).toLocaleString()}
-          <br />
-          <b>To:</b>{' '}
-          {maintenance.end ? new Date(maintenance.end).toLocaleString() : 'Until further notice'}
-        </div>
+        <b>From:</b> {new Date(maintenance.start).toLocaleString()}
+        <br />
+        <b>To:</b>{' '}
+        {maintenance.end ? new Date(maintenance.end).toLocaleString() : 'Until further notice'}
+      </div>
 
-        <Text>{maintenance.body}</Text>
-        {maintenance.monitors && maintenance.monitors.length > 0 && (
-          <>
-            <Text mt="xs">
-              <b>Affected components:</b>
-            </Text>
-            <List size="sm" withPadding>
-              {maintenance.monitors.map((comp, compIdx) => (
-                <List.Item key={compIdx}>{comp.name}</List.Item>
-              ))}
-            </List>
-          </>
-        )}
-      </Alert>
-    </div>
+      <Text>{maintenance.body}</Text>
+      {maintenance.monitors && maintenance.monitors.length > 0 && (
+        <>
+          <Text mt="xs">
+            <b>Affected components:</b>
+          </Text>
+          <List size="sm" withPadding>
+            {maintenance.monitors.map((comp, compIdx) => (
+              <List.Item key={compIdx}>{comp.name}</List.Item>
+            ))}
+          </List>
+        </>
+      )}
+    </Alert>
   )
 }

--- a/components/MaintenanceAlert.tsx
+++ b/components/MaintenanceAlert.tsx
@@ -1,4 +1,5 @@
-import { Alert, List, Text } from '@mantine/core'
+import { Alert, List, Text, useMantineTheme } from '@mantine/core'
+import { useMediaQuery } from '@mantine/hooks'
 import { IconAlertTriangle } from '@tabler/icons-react'
 import { MaintenanceConfig, MonitorTarget } from '@/types/config'
 
@@ -9,32 +10,42 @@ export default function MaintenanceAlert({
   maintenance: Omit<MaintenanceConfig, 'monitors'> & { monitors?: MonitorTarget[] }
   style?: React.CSSProperties
 }) {
-  const titleStyle: React.CSSProperties = {}
+  const theme = useMantineTheme()
+  const isDesktop = useMediaQuery(`(min-width: ${theme.breakpoints.sm})`)
 
   return (
     <Alert
       icon={<IconAlertTriangle />}
       title={
-        (
-          <span style={titleStyle}>
-            {maintenance.title || 'Scheduled Maintenance'}
-          </span>
-        )
+        <span
+          style={{
+            fontSize: '1rem',
+            fontWeight: 700,
+          }}
+        >
+          {maintenance.title || 'Scheduled Maintenance'}
+        </span>
       }
       color={maintenance.color || 'yellow'}
       withCloseButton={false}
       style={{ position: 'relative', margin: '16px auto 0 auto', ...style }}
     >
-      {/* Date range in top right */}
+      {/* Date range in top right (desktop) or inline (mobile) */}
       <div
         style={{
-          position: 'absolute',
-          top: 10,
-          right: 10,
-          fontSize: '0.85rem',
-          textAlign: 'right',
-          padding: '2px 8px',
-          borderRadius: 6,
+          ...{
+            top: 10,
+            fontSize: '0.85rem',
+            borderRadius: 6,
+          },
+          ...(isDesktop
+            ? {
+                position: 'absolute',
+                right: 10,
+                padding: '2px 8px',
+                textAlign: 'right',
+              }
+            : {}),
         }}
       >
         <b>From:</b> {new Date(maintenance.start).toLocaleString()}
@@ -43,7 +54,7 @@ export default function MaintenanceAlert({
         {maintenance.end ? new Date(maintenance.end).toLocaleString() : 'Until further notice'}
       </div>
 
-      <Text>{maintenance.body}</Text>
+      <Text style={{ paddingTop: '3px' }}>{maintenance.body}</Text>
       {maintenance.monitors && maintenance.monitors.length > 0 && (
         <>
           <Text mt="xs">

--- a/components/MaintenanceAlert.tsx
+++ b/components/MaintenanceAlert.tsx
@@ -29,9 +29,9 @@ export default function MaintenanceAlert({
         title={
           (
             <span style={titleStyle} onClick={updateHash}>
-              {maintenance.title}
+              {maintenance.title || 'Scheduled Maintenance'}
             </span>
-          ) || 'Scheduled Maintenance'
+          )
         }
         color={maintenance.color || 'yellow'}
         withCloseButton={false}

--- a/components/MaintenanceAlert.tsx
+++ b/components/MaintenanceAlert.tsx
@@ -5,49 +5,70 @@ import { MaintenanceConfig, MonitorTarget } from '@/types/config'
 export default function MaintenanceAlert({
   maintenance,
   style,
+  hash,
 }: {
   maintenance: Omit<MaintenanceConfig, 'monitors'> & { monitors?: MonitorTarget[] }
   style?: React.CSSProperties
+  hash?: string
 }) {
-  return (
-    <Alert
-      icon={<IconAlertTriangle />}
-      title={maintenance.title || 'Scheduled Maintenance'}
-      color={maintenance.color || 'yellow'}
-      withCloseButton={false}
-      style={{ position: 'relative', margin: '16px auto 0 auto', ...style }}
-    >
-      {/* Date range in top right */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 10,
-          right: 10,
-          fontSize: '0.85rem',
-          textAlign: 'right',
-          padding: '2px 8px',
-          borderRadius: 6,
-        }}
-      >
-        <b>From:</b> {new Date(maintenance.start).toLocaleString()}
-        <br />
-        <b>To:</b>{' '}
-        {maintenance.end ? new Date(maintenance.end).toLocaleString() : 'Until further notice'}
-      </div>
+  const titleStyle: React.CSSProperties = {}
+  if (hash) {
+    titleStyle['textDecoration'] = 'underline'
+    titleStyle['cursor'] = 'pointer'
+  }
 
-      <Text>{maintenance.body}</Text>
-      {maintenance.monitors && maintenance.monitors.length > 0 && (
-        <>
-          <Text mt="xs">
-            <b>Affected components:</b>
-          </Text>
-          <List size="sm" withPadding>
-            {maintenance.monitors.map((comp, compIdx) => (
-              <List.Item key={compIdx}>{comp.name}</List.Item>
-            ))}
-          </List>
-        </>
-      )}
-    </Alert>
+  function updateHash() {
+    if (!hash) return
+    window.location.hash = hash
+  }
+
+  return (
+    <div id={hash}>
+      <Alert
+        icon={<IconAlertTriangle />}
+        title={
+          (
+            <span style={titleStyle} onClick={updateHash}>
+              {maintenance.title}
+            </span>
+          ) || 'Scheduled Maintenance'
+        }
+        color={maintenance.color || 'yellow'}
+        withCloseButton={false}
+        style={{ position: 'relative', margin: '16px auto 0 auto', ...style }}
+      >
+        {/* Date range in top right */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 10,
+            right: 10,
+            fontSize: '0.85rem',
+            textAlign: 'right',
+            padding: '2px 8px',
+            borderRadius: 6,
+          }}
+        >
+          <b>From:</b> {new Date(maintenance.start).toLocaleString()}
+          <br />
+          <b>To:</b>{' '}
+          {maintenance.end ? new Date(maintenance.end).toLocaleString() : 'Until further notice'}
+        </div>
+
+        <Text>{maintenance.body}</Text>
+        {maintenance.monitors && maintenance.monitors.length > 0 && (
+          <>
+            <Text mt="xs">
+              <b>Affected components:</b>
+            </Text>
+            <List size="sm" withPadding>
+              {maintenance.monitors.map((comp, compIdx) => (
+                <List.Item key={compIdx}>{comp.name}</List.Item>
+              ))}
+            </List>
+          </>
+        )}
+      </Alert>
+    </div>
   )
 }

--- a/components/NoIncidents.tsx
+++ b/components/NoIncidents.tsx
@@ -5,7 +5,16 @@ export default function NoIncidentsAlert({ style }: { style?: React.CSSPropertie
   return (
     <Alert
       icon={<IconInfoCircle />}
-      title="No Incidents in this month"
+      title={
+        <span
+          style={{
+            fontSize: '1rem',
+            fontWeight: 700,
+          }}
+        >
+          {'No incidents in this month'}
+        </span>
+      }
       color="gray"
       withCloseButton={false}
       style={{
@@ -14,18 +23,6 @@ export default function NoIncidentsAlert({ style }: { style?: React.CSSPropertie
         ...style,
       }}
     >
-      <div
-        style={{
-          position: 'absolute',
-          top: 10,
-          right: 10,
-          fontSize: '0.85rem',
-          textAlign: 'right',
-          padding: '2px 8px',
-          borderRadius: 6,
-          color: '#888',
-        }}
-      ></div>
       <Text>There are no incidents for this month.</Text>
     </Alert>
   )

--- a/components/NoIncidents.tsx
+++ b/components/NoIncidents.tsx
@@ -1,0 +1,32 @@
+import { Alert, Text } from '@mantine/core'
+import { IconInfoCircle } from '@tabler/icons-react'
+
+export default function NoIncidentsAlert({ style }: { style?: React.CSSProperties }) {
+  return (
+    <Alert
+      icon={<IconInfoCircle />}
+      title="No Incidents in this month"
+      color="gray"
+      withCloseButton={false}
+      style={{
+        position: 'relative',
+        margin: '16px auto 0 auto',
+        ...style,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 10,
+          right: 10,
+          fontSize: '0.85rem',
+          textAlign: 'right',
+          padding: '2px 8px',
+          borderRadius: 6,
+          color: '#888',
+        }}
+      ></div>
+      <Text>There are no incidents for this month.</Text>
+    </Alert>
+  )
+}

--- a/pages/incidents.tsx
+++ b/pages/incidents.tsx
@@ -23,7 +23,17 @@ function getSelectedMonth() {
     const now = new Date()
     return now.getFullYear() + '-' + String(now.getMonth() + 1).padStart(2, '0')
   }
-  return hash
+  return hash.split('-').splice(0, 2).join('-')
+}
+
+function getIncidentHash() {
+  const hash = window.location.hash.replace('#', '')
+  const splitted = hash?.split('-')
+  if (hash && splitted.length >= 3) {
+    return splitted[2]
+  }
+
+  return null
 }
 
 function filterIncidentsByMonth(
@@ -107,7 +117,15 @@ export default function IncidentsPage() {
                 <NoIncidentsAlert />
               ) : (
                 monitorFilteredIncidents.map((incident, i) => (
-                  <MaintenanceAlert key={i} maintenance={incident} />
+                  <MaintenanceAlert
+                    key={i}
+                    hash={[
+                      new Date(incident.start).getFullYear(),
+                      String(new Date(incident.start).getMonth() + 1).padStart(2, '0'),
+                      monitorFilteredIncidents.length - i,
+                    ].join('-')}
+                    maintenance={incident}
+                  />
                 ))
               )}
             </Box>

--- a/pages/incidents.tsx
+++ b/pages/incidents.tsx
@@ -40,6 +40,7 @@ function filterIncidentsByMonth(
       ...e,
       monitors: (e.monitors || []).map((e) => workerConfig.monitors.find((mon) => mon.id === e)!),
     }))
+    .sort((a, b) => (new Date(a.start) > new Date(b.start) ? 1 : -1))
 }
 
 function getPrevNextMonth(monthStr: string) {

--- a/pages/incidents.tsx
+++ b/pages/incidents.tsx
@@ -1,14 +1,10 @@
 import Head from 'next/head'
 
 import { Inter } from 'next/font/google'
-import { MaintenanceConfig, MonitorState, MonitorTarget } from '@/types/config'
-import { KVNamespace } from '@cloudflare/workers-types'
+import { MaintenanceConfig, MonitorTarget } from '@/types/config'
 import { maintenances, pageConfig, workerConfig } from '@/uptime.config'
-import OverallStatus from '@/components/OverallStatus'
 import Header from '@/components/Header'
-import MonitorList from '@/components/MonitorList'
-import { Box, Button, Center, Container, Divider, Group, Select, Text } from '@mantine/core'
-import MonitorDetail from '@/components/MonitorDetail'
+import { Box, Button, Center, Container, Group, Select } from '@mantine/core'
 import Footer from '@/components/Footer'
 import { useEffect, useState } from 'react'
 import MaintenanceAlert from '@/components/MaintenanceAlert'
@@ -24,16 +20,6 @@ function getSelectedMonth() {
     return now.getFullYear() + '-' + String(now.getMonth() + 1).padStart(2, '0')
   }
   return hash.split('-').splice(0, 2).join('-')
-}
-
-function getIncidentHash() {
-  const hash = window.location.hash.replace('#', '')
-  const splitted = hash?.split('-')
-  if (hash && splitted.length >= 3) {
-    return splitted[2]
-  }
-
-  return null
 }
 
 function filterIncidentsByMonth(

--- a/pages/incidents.tsx
+++ b/pages/incidents.tsx
@@ -119,11 +119,6 @@ export default function IncidentsPage() {
                 monitorFilteredIncidents.map((incident, i) => (
                   <MaintenanceAlert
                     key={i}
-                    hash={[
-                      new Date(incident.start).getFullYear(),
-                      String(new Date(incident.start).getMonth() + 1).padStart(2, '0'),
-                      monitorFilteredIncidents.length - i,
-                    ].join('-')}
                     maintenance={incident}
                   />
                 ))

--- a/pages/incidents.tsx
+++ b/pages/incidents.tsx
@@ -40,7 +40,7 @@ function filterIncidentsByMonth(
       ...e,
       monitors: (e.monitors || []).map((e) => workerConfig.monitors.find((mon) => mon.id === e)!),
     }))
-    .sort((a, b) => (new Date(a.start) > new Date(b.start) ? 1 : -1))
+    .sort((a, b) => (new Date(a.start) > new Date(b.start) ? -1 : 1))
 }
 
 function getPrevNextMonth(monthStr: string) {

--- a/pages/incidents.tsx
+++ b/pages/incidents.tsx
@@ -1,0 +1,130 @@
+import Head from 'next/head'
+
+import { Inter } from 'next/font/google'
+import { MaintenanceConfig, MonitorState, MonitorTarget } from '@/types/config'
+import { KVNamespace } from '@cloudflare/workers-types'
+import { maintenances, pageConfig, workerConfig } from '@/uptime.config'
+import OverallStatus from '@/components/OverallStatus'
+import Header from '@/components/Header'
+import MonitorList from '@/components/MonitorList'
+import { Box, Button, Center, Container, Divider, Group, Select, Text } from '@mantine/core'
+import MonitorDetail from '@/components/MonitorDetail'
+import Footer from '@/components/Footer'
+import { useEffect, useState } from 'react'
+import MaintenanceAlert from '@/components/MaintenanceAlert'
+import NoIncidentsAlert from '@/components/NoIncidents'
+
+export const runtime = 'experimental-edge'
+const inter = Inter({ subsets: ['latin'] })
+
+function getSelectedMonth() {
+  const hash = window.location.hash.replace('#', '')
+  if (!hash) {
+    const now = new Date()
+    return now.getFullYear() + '-' + String(now.getMonth() + 1).padStart(2, '0')
+  }
+  return hash
+}
+
+function filterIncidentsByMonth(
+  incidents: MaintenanceConfig[],
+  monthStr: string
+): (Omit<MaintenanceConfig, 'monitors'> & { monitors: MonitorTarget[] })[] {
+  return incidents
+    .filter((incident) => {
+      const d = new Date(incident.start)
+      const incidentMonth = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0')
+      return incidentMonth === monthStr
+    })
+    .map((e) => ({
+      ...e,
+      monitors: (e.monitors || []).map((e) => workerConfig.monitors.find((mon) => mon.id === e)!),
+    }))
+}
+
+function getPrevNextMonth(monthStr: string) {
+  const [year, month] = monthStr.split('-').map(Number)
+  const date = new Date(year, month - 1)
+  const prev = new Date(date)
+  prev.setMonth(prev.getMonth() - 1)
+  const next = new Date(date)
+  next.setMonth(next.getMonth() + 1)
+  return {
+    prev: prev.getFullYear() + '-' + String(prev.getMonth() + 1).padStart(2, '0'),
+    next: next.getFullYear() + '-' + String(next.getMonth() + 1).padStart(2, '0'),
+  }
+}
+
+export default function IncidentsPage() {
+  const [selectedMonitor, setSelectedMonitor] = useState<string | null>('')
+  const [selectedMonth, setSelectedMonth] = useState(getSelectedMonth())
+
+  useEffect(() => {
+    const onHashChange = () => setSelectedMonth(getSelectedMonth())
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
+  const filteredIncidents = filterIncidentsByMonth(maintenances, selectedMonth)
+  const monitorFilteredIncidents = selectedMonitor
+    ? filteredIncidents.filter((i) => i.monitors.find((e) => e.id === selectedMonitor))
+    : filteredIncidents
+
+  const { prev, next } = getPrevNextMonth(selectedMonth)
+
+  const monitorOptions = [
+    { value: '', label: 'All' },
+    ...workerConfig.monitors.map((monitor) => ({
+      value: monitor.id,
+      label: monitor.name,
+    })),
+  ]
+
+  return (
+    <>
+      <Head>
+        <title>{pageConfig.title}</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      <main className={inter.className}>
+        <Header />
+        <Center>
+          <Container size="md" style={{ width: '100%' }}>
+            <Group justify="end" mb="md">
+              <Select
+                placeholder="Select monitor"
+                data={monitorOptions}
+                value={selectedMonitor}
+                onChange={setSelectedMonitor}
+                clearable
+                style={{ maxWidth: 300, float: 'right' }}
+              />
+            </Group>
+            <Box>
+              {monitorFilteredIncidents.length === 0 ? (
+                <NoIncidentsAlert />
+              ) : (
+                monitorFilteredIncidents.map((incident, i) => (
+                  <MaintenanceAlert key={i} maintenance={incident} />
+                ))
+              )}
+            </Box>
+            <Group justify="space-between" mt="md">
+              <Button variant="default" onClick={() => (window.location.hash = prev)}>
+                ← Backwards
+              </Button>
+              <Box style={{ alignSelf: 'center', fontWeight: 500, fontSize: 18 }}>
+                {selectedMonth}
+              </Box>
+              <Button variant="default" onClick={() => (window.location.hash = next)}>
+                Forward →
+              </Button>
+            </Group>
+          </Container>
+        </Center>
+        <Footer />
+      </main>
+    </>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,8 +7,9 @@ import { maintenances, pageConfig, workerConfig } from '@/uptime.config'
 import OverallStatus from '@/components/OverallStatus'
 import Header from '@/components/Header'
 import MonitorList from '@/components/MonitorList'
-import { Center, Divider, Text } from '@mantine/core'
+import { Center, Text } from '@mantine/core'
 import MonitorDetail from '@/components/MonitorDetail'
+import Footer from '@/components/Footer'
 
 export const runtime = 'experimental-edge'
 const inter = Inter({ subsets: ['latin'] })
@@ -65,29 +66,7 @@ export default function Home({
           </div>
         )}
 
-        <Divider mt="lg" />
-        <Text
-          size="xs"
-          mt="xs"
-          mb="xs"
-          style={{
-            textAlign: 'center',
-          }}
-        >
-          Open-source monitoring and status page powered by{' '}
-          <a href="https://github.com/lyc8503/UptimeFlare" target="_blank">
-            Uptimeflare
-          </a>{' '}
-          and{' '}
-          <a href="https://www.cloudflare.com/" target="_blank">
-            Cloudflare
-          </a>
-          , made with ❤ by{' '}
-          <a href="https://github.com/lyc8503" target="_blank">
-            lyc8503
-          </a>
-          .
-        </Text>
+        <Footer />
       </main>
     </>
   )

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -1,6 +1,6 @@
 .header {
   height: rem(56px);
-  margin-bottom: rem(40px);
+  margin-bottom: rem(100px);
   background-color: var(--mantine-color-body);
   border-bottom: rem(1px) solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -1,6 +1,6 @@
 .header {
   height: rem(56px);
-  margin-bottom: rem(120px);
+  margin-bottom: rem(40px);
   background-color: var(--mantine-color-body);
   border-bottom: rem(1px) solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }


### PR DESCRIPTION
closes #110

Hey,
first draft arrived. Live-Version with some maintenances can be found here: https://uptimeflar-dev.pages.dev/incidents#2025-05

Things I did not yet do: 
1. Anchor link per incident. I don't know if we want to give the user a "copy link" button on the incident card(?) or how the link should be displayed.
2. There should be a link back to the main page. I think perhaps it's time to replace the "🕒UptimeFlare" on the top right with perhaps an image and then a link to the startpage. 

I've moved the footer stuff into a seperate component and removed a lot of margin-bottom on the header so the distance to the content is not that great anymore, I think this is necessary to not have that much wasted space.

Filtering and everything is done in the frontend obviously. I've also realized that the uptimeflare.config.ts is build at run-time for each request? Wouldn't it be cooler if it could be compiled into the distribution files?
