### PR TITLE
Add ability to change header icon and name

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
         <div>
           <a href="https://github.com/lyc8503/UptimeFlare" target="_blank">
             <Text size="xl" span>
-              🕒
+              {pageConfig.header-icon}
             </Text>
             <Text
               size="xl"
@@ -33,7 +33,7 @@ export default function Header() {
               variant="gradient"
               gradient={{ from: 'blue', to: 'cyan', deg: 90 }}
             >
-              UptimeFlare
+              {pageConfig.header}
             </Text>
           </a>
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
         <div>
           <a href="https://github.com/lyc8503/UptimeFlare" target="_blank">
             <Text size="xl" span>
-              {pageConfig.header-icon}
+              {pageConfig.headericon}
             </Text>
             <Text
               size="xl"

--- a/types/config.ts
+++ b/types/config.ts
@@ -1,5 +1,7 @@
 export type PageConfig = {
   title?: string
+  headericon?: string
+  header?: string
   links?: PageConfigLink[]
   group?: PageConfigGroup
 }

--- a/uptime.config.ts
+++ b/uptime.config.ts
@@ -3,7 +3,7 @@ import { MaintenanceConfig, PageConfig, WorkerConfig } from './types/config'
 const pageConfig: PageConfig = {
   // Title for your status page
   title: "lyc8503's Status Page",
-  header-icon: "🕒",
+  headericon: "🕒",
   header: "UptimeFlare",
   // Links shown at the header of your status page, could set `highlight` to `true`
   links: [

--- a/uptime.config.ts
+++ b/uptime.config.ts
@@ -3,6 +3,8 @@ import { MaintenanceConfig, PageConfig, WorkerConfig } from './types/config'
 const pageConfig: PageConfig = {
   // Title for your status page
   title: "lyc8503's Status Page",
+  header-icon: "🕒",
+  header: "UptimeFlare",
   // Links shown at the header of your status page, could set `highlight` to `true`
   links: [
     { link: 'https://github.com/lyc8503', label: 'GitHub' },


### PR DESCRIPTION
Added the following, to allow changing of the Header Icon & Text

```
const pageConfig: PageConfig = {
....
  headericon: "🕒",
  header: "UptimeFlare",
.....
}
```

![image](https://github.com/user-attachments/assets/fe01e902-6819-4358-8efc-176dd0c58381)
