### PR TITLE
fix: improve types for callback-related config

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -1,3 +1,5 @@
+import type { Env } from '../worker/src'
+
 export type PageConfig = {
   title?: string
   links?: PageConfigLink[]
@@ -39,12 +41,12 @@ export type MonitorTarget = {
   checkProxyFallback?: boolean
 }
 
-export type WorkerConfig = {
+export type WorkerConfig<TEnv = Env> = {
   kvWriteCooldownMinutes: number
   passwordProtection?: string
   monitors: MonitorTarget[]
   notification?: Notification
-  callbacks?: Callbacks
+  callbacks?: Callbacks<TEnv>
 }
 
 export type Notification = {
@@ -55,9 +57,9 @@ export type Notification = {
   skipNotificationIds?: string[]
 }
 
-export type Callbacks = {
+export type Callbacks<TEnv = Env> = {
   onStatusChange?: (
-    env: any,
+    env: TEnv,
     monitor: MonitorTarget,
     isUp: boolean,
     timeIncidentStart: number,
@@ -65,7 +67,7 @@ export type Callbacks = {
     reason: string
   ) => Promise<any> | any
   onIncident?: (
-    env: any,
+    env: TEnv,
     monitor: MonitorTarget,
     timeIncidentStart: number,
     timeNow: number,

--- a/types/config.ts
+++ b/types/config.ts
@@ -56,7 +56,7 @@ export type Notification = {
 }
 
 export type Callbacks = {
-  onStatusChange: (
+  onStatusChange?: (
     env: any,
     monitor: any,
     isUp: boolean,
@@ -64,7 +64,7 @@ export type Callbacks = {
     timeNow: number,
     reason: string
   ) => Promise<any>
-  onIncident: (
+  onIncident?: (
     env: any,
     monitor: any,
     timeIncidentStart: number,

--- a/types/config.ts
+++ b/types/config.ts
@@ -63,14 +63,14 @@ export type Callbacks = {
     timeIncidentStart: number,
     timeNow: number,
     reason: string
-  ) => Promise<any>
+  ) => Promise<any> | any
   onIncident?: (
     env: any,
     monitor: any,
     timeIncidentStart: number,
     timeNow: number,
     reason: string
-  ) => Promise<any>
+  ) => Promise<any> | any
 }
 
 export type MonitorState = {

--- a/types/config.ts
+++ b/types/config.ts
@@ -58,7 +58,7 @@ export type Notification = {
 export type Callbacks = {
   onStatusChange?: (
     env: any,
-    monitor: any,
+    monitor: MonitorTarget,
     isUp: boolean,
     timeIncidentStart: number,
     timeNow: number,
@@ -66,7 +66,7 @@ export type Callbacks = {
   ) => Promise<any> | any
   onIncident?: (
     env: any,
-    monitor: any,
+    monitor: MonitorTarget,
     timeIncidentStart: number,
     timeNow: number,
     reason: string

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -179,7 +179,7 @@ const Worker = {
             }
 
             console.log('Calling config onStatusChange callback...')
-            await workerConfig.callbacks?.onStatusChange(
+            await workerConfig.callbacks?.onStatusChange?.(
               env,
               monitor,
               true,
@@ -250,7 +250,7 @@ const Worker = {
 
           if (monitorStatusChanged) {
             console.log('Calling config onStatusChange callback...')
-            await workerConfig.callbacks?.onStatusChange(
+            await workerConfig.callbacks?.onStatusChange?.(
               env,
               monitor,
               false,
@@ -266,7 +266,7 @@ const Worker = {
 
         try {
           console.log('Calling config onIncident callback...')
-          await workerConfig.callbacks?.onIncident(
+          await workerConfig.callbacks?.onIncident?.(
             env,
             monitor,
             currentIncident.start[0],


### PR DESCRIPTION
## Description
The callback-related configuration types were insufficient and difficult to use, so we improved them to be more flexible and type-safe.

## Changes

### 1. Enable partial callback specification
Previously, when specifying callbacks, all callbacks had to be defined, even if you only wanted to use one. Empty functions had to be provided for unused callbacks.

**Before:**
```ts
callbacks: {
  // ^ Property 'onIncident' is missing in type '{ onStatusChange: (env: any, monitor: any, isUp: boolean, timeIncidentStart: number, timeNow: number, reason: string) => Promise<void>; }' but required in type 'Callbacks'.ts(2741)
  onStatusChange: async (env, monitor, isUp, timeIncidentStart, timeNow, reason) => {},
},
```

**After:**
Now callbacks are optional - you can specify only the ones you need.

### 2. Support both sync and async functions
Some use cases, such as simple logging in Cloudflare Workers, may prefer synchronous functions. We've modified the types to accept both sync and async functions.

**Before:**
```ts
callbacks: {
  // ^ Type '(env: any, monitor: any, isUp: boolean, timeIncidentStart: number, timeNow: number, reason: string) => void' is not assignable to type '(env: any, monitor: any, isUp: boolean, timeIncidentStart: number, timeNow: number, reason: string) => Promise<any>'.
  // Type 'void' is not assignable to type 'Promise<any>'.ts(2322)
  onStatusChange: (env, monitor, isUp, timeIncidentStart, timeNow, reason) => {
    console.log(`Monitor ${monitor.name} is now ${isUp ? 'up' : 'down'}. Reason: ${reason}`);
  },
},
```

**After:**
Both sync and async functions are now supported.

### 3. Improve type safety by replacing `any` types
We've replaced `any` types with proper type definitions and made `env` a generic type parameter with `Env` as the default.

**Basic usage:**
```ts
callbacks: {
  onStatusChange: async (env, monitor, isUp, timeIncidentStart, timeNow, reason) => {
    env
    // ^? { UPTIMEFLARE_STATE: KVNamespace<string>; REMOTE_CHECKER_DO: DurableObjectNamespace<RemoteChecker>; }
  },
},
```

**Custom environment types:**
If you need to use Cloudflare Workers secrets or other custom environment variables, you can specify your own type:

```ts
import { Env } from './worker/src'

interface MyEnv extends Env {
  MY_SECRET: string
}

const workerConfig: WorkerConfig<MyEnv> = {
  // ... other configs
  callbacks: {
    onStatusChange: async (env, monitor, isUp, timeIncidentStart, timeNow, reason) => {
      env.MY_SECRET
      //  ^? string
    },
  },
}
```