### PR TITLE
Add webhook support to notification property in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ Please refer to [Wiki](https://github.com/lyc8503/UptimeFlare/wiki)
 - [ ] Cloudflare D1 database
 - [x] Scheduled maintenances (via IIFE)
 - [ ] Simpler config example
-- [ ] Upcoming maintenances
-- [ ] Universal Webhook upgrade
+- [x] Upcoming maintenances
+- [x] Universal Webhook upgrade

--- a/types/config.ts
+++ b/types/config.ts
@@ -54,14 +54,14 @@ export type Notification = {
   recipientUrl?: string
   timeZone?: string
   gracePeriod?: number
-  skipNotificationIds?: string[],
+  skipNotificationIds?: string[]
   webhook?: Webhook
 }
 
 export type Webhook = {
-  url: string,
-  method?: 'POST' | 'GET',
-  headers?: { [key: string]: string | number },
+  url: string
+  method?: 'POST' | 'GET'
+  headers?: { [key: string]: string | number }
   timeout?: number
 }
 

--- a/types/config.ts
+++ b/types/config.ts
@@ -58,11 +58,19 @@ export type Notification = {
   webhook?: Webhook
 }
 
-export type Webhook = {
+export type Webhook<TEnv = Env> = {
   url: string
   method?: 'POST' | 'GET'
   headers?: { [key: string]: string | number }
   timeout?: number
+  body?: (
+    env: TEnv,
+    monitor: MonitorTarget,
+    isUp: boolean,
+    timeIncidentStart: number,
+    timeNow: number,
+    reason: string
+  ) => { [key: string]: any } | string
 }
 
 export type Callbacks<TEnv = Env> = {

--- a/types/config.ts
+++ b/types/config.ts
@@ -54,7 +54,15 @@ export type Notification = {
   recipientUrl?: string
   timeZone?: string
   gracePeriod?: number
-  skipNotificationIds?: string[]
+  skipNotificationIds?: string[],
+  webhook?: Webhook
+}
+
+export type Webhook = {
+  url: string,
+  method?: 'POST' | 'GET',
+  headers?: { [key: string]: string | number },
+  timeout?: number
 }
 
 export type Callbacks<TEnv = Env> = {

--- a/types/config.ts
+++ b/types/config.ts
@@ -54,27 +54,19 @@ export type WorkerConfig<TEnv = Env> = {
 }
 
 export type Notification = {
-  appriseApiServer?: string
-  recipientUrl?: string
+  webhook?: WebhookConfig
   timeZone?: string
   gracePeriod?: number
   skipNotificationIds?: string[]
-  webhook?: Webhook
 }
 
-export type Webhook<TEnv = Env> = {
+export type WebhookConfig = {
   url: string
-  method?: 'POST' | 'GET'
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH'
   headers?: { [key: string]: string | number }
+  payloadType: 'param' | 'json' | 'x-www-form-urlencoded'
+  payload: { [key: string]: string | number }
   timeout?: number
-  body?: (
-    env: TEnv,
-    monitor: MonitorTarget,
-    isUp: boolean,
-    timeIncidentStart: number,
-    timeNow: number,
-    reason: string
-  ) => { [key: string]: any } | string
 }
 
 export type Callbacks<TEnv = Env> = {

--- a/uptime.config.ts
+++ b/uptime.config.ts
@@ -91,6 +91,21 @@ const workerConfig: WorkerConfig = {
     gracePeriod: 5,
     // [Optional] disable notification for monitors with specified ids
     skipNotificationIds: ['foo_monitor', 'bar_monitor'],
+    /* [Optional] use webhook configuration instead of apprise configuration (appriseApiServer & recipientUrl)
+    webhook: {
+      // [Required] webhook URL
+      url: 'https://hooks.zapier.com/hooks/catch/123456/abcdef/',
+      // [Optional] HTTP method, default to "POST"
+      method: 'POST',
+      // [Optional] headers to be sent
+      headers: {
+        // [Optional] header defaults to Content-Type: application/json, additional properties will be merged, example of authorization header below
+        'Authorization': 'Bearer YOUR_TOKEN_HERE',
+      },
+      // [Optional] timeout in millisecond, defaults to 30000
+      timeout: 30000,
+    },
+    */
   },
   callbacks: {
     onStatusChange: async (
@@ -143,4 +158,5 @@ const maintenances: MaintenanceConfig[] = [
 ]
 
 // Don't forget this, otherwise compilation fails.
-export { pageConfig, workerConfig, maintenances }
+export { maintenances, pageConfig, workerConfig }
+

--- a/uptime.config.ts
+++ b/uptime.config.ts
@@ -102,6 +102,19 @@ const workerConfig: WorkerConfig = {
         // [Optional] header defaults to Content-Type: application/json, additional properties will be merged, example of authorization header below
         'Authorization': 'Bearer YOUR_TOKEN_HERE',
       },
+      // [Optional] body to be sent, could be an object or a string
+      // if it's an object, it will be sent as JSON
+      // if it's a string, it will be sent as-is
+      body: (env, monitor, isUp, timeIncidentStart, timeNow, reason) => {
+        return {
+          event: 'status_change',
+          monitor,
+          isUp,
+          timeIncidentStart,
+          timeNow,
+          reason,
+        }
+      },
       // [Optional] timeout in millisecond, defaults to 30000
       timeout: 30000,
     },

--- a/uptime.config.ts
+++ b/uptime.config.ts
@@ -84,13 +84,34 @@ const workerConfig: WorkerConfig = {
       timeout: 5000,
     },
   ],
+  // [Optional] Notification settings
   notification: {
-    // [Optional] apprise API server URL
-    // if not specified, no notification will be sent
-    appriseApiServer: 'https://apprise.example.com/notify',
-    // [Optional] recipient URL for apprise, refer to https://github.com/caronc/apprise
-    // if not specified, no notification will be sent
-    recipientUrl: 'tgram://bottoken/ChatID',
+    // [Optional] Notification webhook settings, if not specified, no notification will be sent
+    // Wiki: TODO
+    webhook: {
+      // [Required] webhook URL (example: Telegram Bot API)
+      url: 'https://api.telegram.org/bot123456:ABCDEF/sendMessage',
+      // [Optional] HTTP method, default to 'GET' for payloadType=param, 'POST' otherwise
+      method: 'POST',
+      // [Optional] headers to be sent
+      headers: {
+        foo: 'bar',
+      },
+      // [Required] Specify how to encode the payload
+      // Should be one of 'param', 'json' or 'x-www-form-urlencoded'
+      // 'param': append url-encoded payload to URL search parameters
+      // 'json': POST json payload as body, set content-type header to 'application/json'
+      // 'x-www-form-urlencoded': POST url-encoded payload as body, set content-type header to 'x-www-form-urlencoded'
+      payloadType: 'x-www-form-urlencoded',
+      // [Required] payload to be sent
+      // $MSG will be replaced with the human-readable notification message
+      payload: {
+        chat_id: 12345678,
+        text: '$MSG',
+      },
+      // [Optional] timeout calling this webhook, in millisecond, default to 5000
+      timeout: 10000,
+    },
     // [Optional] timezone used in notification messages, default to "Etc/GMT"
     timeZone: 'Asia/Shanghai',
     // [Optional] grace period in minutes before sending a notification
@@ -99,34 +120,6 @@ const workerConfig: WorkerConfig = {
     gracePeriod: 5,
     // [Optional] disable notification for monitors with specified ids
     skipNotificationIds: ['foo_monitor', 'bar_monitor'],
-    /* [Optional] use webhook configuration instead of apprise configuration (appriseApiServer & recipientUrl)
-    webhook: {
-      // [Required] webhook URL
-      url: 'https://hooks.zapier.com/hooks/catch/123456/abcdef/',
-      // [Optional] HTTP method, default to "POST"
-      method: 'POST',
-      // [Optional] headers to be sent
-      headers: {
-        // [Optional] header defaults to Content-Type: application/json, additional properties will be merged, example of authorization header below
-        'Authorization': 'Bearer YOUR_TOKEN_HERE',
-      },
-      // [Optional] body to be sent, could be an object or a string
-      // if it's an object, it will be sent as JSON
-      // if it's a string, it will be sent as-is
-      body: (env, monitor, isUp, timeIncidentStart, timeNow, reason) => {
-        return {
-          event: 'status_change',
-          monitor,
-          isUp,
-          timeIncidentStart,
-          timeNow,
-          reason,
-        }
-      },
-      // [Optional] timeout in millisecond, defaults to 30000
-      timeout: 30000,
-    },
-    */
   },
   callbacks: {
     onStatusChange: async (
@@ -181,15 +174,15 @@ const maintenances: MaintenanceConfig[] = [
   // This COULD BE DANGEROUS, as generating too many maintenance entries can lead to performance problems
   // Undeterministic outputs may also lead to bugs or unexpected behavior
   // If you don't know how to DEBUG, use this approach WITH CAUTION
-  ...(function (){
-    const schedules = [];
-    const today = new Date();
+  ...(function () {
+    const schedules = []
+    const today = new Date()
 
     for (let i = -1; i <= 1; i++) {
       // JavaScript's Date object will automatically handle year rollovers
-      const date = new Date(today.getFullYear(), today.getMonth() + i, 15); 
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const date = new Date(today.getFullYear(), today.getMonth() + i, 15)
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
 
       schedules.push({
         title: `${year}/${parseInt(month)} - Test scheduled maintenance`,
@@ -197,12 +190,11 @@ const maintenances: MaintenanceConfig[] = [
         body: 'Monthly scheduled maintenance',
         start: `${year}-${month}-15T02:00:00.000+08:00`,
         end: `${year}-${month}-15T04:00:00.000+08:00`,
-      });
+      })
     }
-    return schedules;
-  })()
+    return schedules
+  })(),
 ]
 
 // Don't forget this, otherwise compilation fails.
 export { maintenances, pageConfig, workerConfig }
-

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2,7 +2,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { MonitorState, MonitorTarget } from '../../types/config'
 import { maintenances, workerConfig } from '../../uptime.config'
 import { getStatus } from './monitor'
-import { formatStatusChangeNotification, getWorkerLocation, notifyWithApprise } from './util'
+import { formatStatusChangeNotification, getWorkerLocation, webhookNotify } from './util'
 
 export interface Env {
   UPTIMEFLARE_STATE: KVNamespace
@@ -14,7 +14,7 @@ const Worker = {
     const workerLocation = (await getWorkerLocation()) || 'ERROR'
     console.log(`Running scheduled event on ${workerLocation}...`)
 
-    // Auxiliary function to format notification and send it via apprise
+    // Auxiliary function to format notification and send it via webhook
     let formatAndNotify = async (
       monitor: MonitorTarget,
       isUp: boolean,
@@ -46,63 +46,18 @@ const Worker = {
         return
       }
 
-      if(workerConfig.notification?.webhook?.url) {
-        const controller = new AbortController()
-        const timeoutId = setTimeout(() => controller.abort(), workerConfig.notification.webhook.timeout ?? 30000) // 30 second default timeout
-        const headers = { 'Content-Type': 'application/json' }
-        let body: { [key: string]: any } | string
-        if(workerConfig.notification.webhook.body) {
-          body = workerConfig.notification.webhook.body(
-            env,
-            monitor,
-            isUp,
-            timeIncidentStart,
-            timeNow,
-            reason
-          )
-        } else {
-          body = {
-            monitor,
-            isUp,
-            timeIncidentStart,
-            timeNow,
-            reason,
-          }
-        }
-        if(workerConfig.notification.webhook.headers) {
-          Object.assign(headers, workerConfig.notification.webhook.headers)
-        }
-        try {
-          await fetch(workerConfig.notification.webhook.url, {
-            method: workerConfig.notification.webhook.method ?? 'POST',
-            headers,
-            body: typeof body === 'object' ? JSON.stringify(body) : body,
-            signal: controller.signal,
-          })
-        } finally {
-          clearTimeout(timeoutId)
-        }
+      if (workerConfig.notification?.webhook) {
+        const notification = formatStatusChangeNotification(
+          monitor,
+          isUp,
+          timeIncidentStart,
+          timeNow,
+          reason,
+          workerConfig.notification?.timeZone ?? 'Etc/GMT'
+        )
+        await webhookNotify(workerConfig.notification.webhook, notification)
       } else {
-        if (workerConfig.notification?.appriseApiServer && workerConfig.notification?.recipientUrl) {
-          const notification = formatStatusChangeNotification(
-            monitor,
-            isUp,
-            timeIncidentStart,
-            timeNow,
-            reason,
-            workerConfig.notification?.timeZone ?? 'Etc/GMT'
-          )
-          await notifyWithApprise(
-            workerConfig.notification.appriseApiServer,
-            workerConfig.notification.recipientUrl,
-            notification.title,
-            notification.body
-          )
-        } else {
-          console.log(
-            `Apprise API server or recipient URL not set, skipping apprise notification for ${monitor.name}`
-          )
-        }
+        console.log(`Webhook not set, skipping notification for ${monitor.name}`)
       }
     }
 
@@ -212,7 +167,7 @@ const Worker = {
               await formatAndNotify(monitor, true, lastIncident.start[0], currentTimeSecond, 'OK')
             } else {
               console.log(
-                `grace period (${workerConfig.notification?.gracePeriod}m) not met, skipping apprise UP notification for ${monitor.name}`
+                `grace period (${workerConfig.notification?.gracePeriod}m) not met, skipping webhook UP notification for ${monitor.name}`
               )
             }
 
@@ -280,7 +235,7 @@ const Worker = {
               `Grace period (${workerConfig.notification
                 ?.gracePeriod}m) not met (currently down for ${
                 currentTimeSecond - currentIncident.start[0]
-              }s, changed ${monitorStatusChanged}), skipping apprise DOWN notification for ${
+              }s, changed ${monitorStatusChanged}), skipping webhook DOWN notification for ${
                 monitor.name
               }`
             )


### PR DESCRIPTION
Check my suggestion for a simple webhook option that can be used for notification as an alternate to apprise.  I made this update on my own install because I didn't want to deal with a whole extra application just to send a simple notification to zapier.

- Updated types/config.ts to update Notification type and add Webhook type
- Updated worker/src/index.ts to add the check for webhook config in formatAndNotify and use it instead if provided
- Updated uptime.config.ts to add (commented out) example configuration (also shown below)
- All other functions of notification property in config continue to work for both options (like timeZone, gracePeriod, etc.)

```
    [Optional] use webhook configuration instead of apprise configuration (appriseApiServer & recipientUrl)
    webhook: {
      // [Required] webhook URL
      url: 'https://hooks.zapier.com/hooks/catch/123456/abcdef/',
      // [Optional] HTTP method, default to "POST"
      method: 'POST',
      // [Optional] headers to be sent
      headers: {
        // [Optional] header defaults to Content-Type: application/json, additional properties will be merged, example of authorization header below
        'Authorization': 'Bearer YOUR_TOKEN_HERE',
      },
      // [Optional] timeout in millisecond, defaults to 30000
      timeout: 30000,
    },
```