### PR TITLE
Added CORS headers to API responses

### DIFF
--- a/pages/api/data.ts
+++ b/pages/api/data.ts
@@ -15,6 +15,9 @@ export default async function handler(req: NextRequest): Promise<Response> {
       status: 500,
       headers: {
         'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
       },
     })
   }
@@ -42,6 +45,9 @@ export default async function handler(req: NextRequest): Promise<Response> {
   return new Response(JSON.stringify(ret), {
     headers: {
       'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
     },
   })
 }


### PR DESCRIPTION
The API for status is showing CORS issue: "Response body is not available to scripts (Reason: CORS Missing Allow Origin)" when using from other domain/localhost. To solve this ,CORS header is added. It also possible to specify allowed domain in Env Var in cloudflare and call them directly. But, here I added CORS origin all so that the API can be called from any host.