### PR TITLE
Add github readme badge api

### DIFF
--- a/pages/api/badge.ts
+++ b/pages/api/badge.ts
@@ -45,6 +45,12 @@ export default async function handler(req: NextRequest): Promise<Response> {
     const url = new URL(req.url)
 
     const monitorId = url.searchParams.get('id')
+    if (!monitorId) {
+      return new Response(JSON.stringify(errorBadge('UptimeFlare', 'id required')), {
+        headers: jsonHeaders,
+        status: 400,
+      })
+    }
     const label = url.searchParams.get('label') ?? 'UptimeFlare'
 
     const upMsg = url.searchParams.get('up') ?? 'UP'

--- a/pages/api/badge.ts
+++ b/pages/api/badge.ts
@@ -78,7 +78,7 @@ export default async function handler(req: NextRequest): Promise<Response> {
       })
     }
 
-    const isUp = Boolean(monitor.up)
+    const isUp = monitor.up
     const badge: BadgePayload = {
       schemaVersion: 1,
       label,

--- a/pages/api/badge.ts
+++ b/pages/api/badge.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from 'next/server'
+
+export const runtime = 'edge'
+
+type DataResponse = {
+  up: number
+  down: number
+  updatedAt: number
+  monitors: Record<
+    string,
+    {
+      up: boolean
+      latency: number
+      location: string
+      message: string
+    }
+  >
+}
+
+type BadgePayload = {
+  schemaVersion: 1
+  label: string
+  message: string
+  color: string
+  isError?: boolean
+}
+
+const jsonHeaders = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store, max-age=0, must-revalidate',
+}
+
+function errorBadge(label: string, message: string): BadgePayload {
+  return {
+    schemaVersion: 1,
+    label,
+    message,
+    color: 'lightgrey',
+    isError: true,
+  }
+}
+
+export default async function handler(req: NextRequest): Promise<Response> {
+  try {
+    const url = new URL(req.url)
+
+    const monitorId = url.searchParams.get('id')
+    const label = url.searchParams.get('label') ?? 'UptimeFlare'
+
+    const upMsg = url.searchParams.get('up') ?? 'UP'
+    const downMsg = url.searchParams.get('down') ?? 'DOWN'
+    const colorUp = url.searchParams.get('colorUp') ?? 'brightgreen'
+    const colorDown = url.searchParams.get('colorDown') ?? 'red'
+
+    const dataUrl = new URL('/api/data', url.origin)
+    const resp = await fetch(dataUrl, { cache: 'no-store' })
+
+    if (!resp.ok) {
+      return new Response(JSON.stringify(errorBadge(label, 'unavailable')), {
+        headers: jsonHeaders,
+        status: resp.status,
+      })
+    }
+
+    const payload = (await resp.json()) as DataResponse
+    const monitor = payload.monitors?.[monitorId]
+
+    if (!monitor) {
+      return new Response(JSON.stringify(errorBadge(label, 'unknown')), {
+        headers: jsonHeaders,
+        status: 404,
+      })
+    }
+
+    const isUp = Boolean(monitor.up)
+    const badge: BadgePayload = {
+      schemaVersion: 1,
+      label,
+      message: isUp ? upMsg : downMsg,
+      color: isUp ? colorUp : colorDown,
+    }
+
+    return new Response(JSON.stringify(badge), {
+      headers: jsonHeaders,
+    })
+  } catch (err) {
+    console.error('Error rendering badge API:', err)
+    return new Response(JSON.stringify(errorBadge('status', 'error')), {
+      headers: jsonHeaders,
+      status: 500,
+    })
+  }
+}


### PR DESCRIPTION
Hi, I’ve created an API that allows you to add GitHub Shields.io badges!

`/api/badge` accepts query-string parameters for selecting a monitor and customizing the badge display, and returns a JSON badge. The basic format is:

```
/api/badge?id=<monitorId>&label=<label>&up=<messageWhenUp>&down=<messageWhenDown>&colorUp=<colorWhenUp>&colorDown=<colorWhenDown>
```

* **`id`** (required): The monitor ID defined in `uptime.config.ts`.
* **`label`** (optional): The label shown on the left side of the badge. Defaults is `UptimeFlare`.
* **`up` / `down`** (optional): Status messages. Defaults are `UP` / `DOWN`.
* **`colorUp` / `colorDown`** (optional): Colors for each state. Defaults are `brightgreen` / `red`.

The response follows the Shields.io JSON format.

---

Here's example:
```
https://status.2jang.dev/api/badge?id=easygym&label=status&up=Online&down=Offline&colorUp=10b981&colorDown=df484a
```

At the end, the response will look like:

```
{"schemaVersion":1,"label":"status","message":"Online","color":"10b981"}
```
When online:
[![status](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.2jang.dev%2Fapi%2Fbadge%3Fid%3Deasygym%26label%3Dstatus%26up%3DOnline%26down%3DOffline%26colorUp%3D10b981%26colorDown%3Ddf484a&style=for-the-badge&logo=cloudflare&logoColor=white&labelColor=FAAD3F)](https://status.2jang.dev)  

When offline:
[![status](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.2jang.dev%2Fapi%2Fbadge%3Fid%3Dtest_tcp_monitor%26label%3Dstatus%26up%3DOnline%26down%3DOffline%26colorUp%3D10b981%26colorDown%3Ddf484a&style=for-the-badge&logo=cloudflare&logoColor=white&labelColor=FAAD3F)](https://status.2jang.dev)  

On error:
[![status](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.2jang.dev%2Fapi%2Fbadge%3Fid%3Dasdasdasdasdasdasd%26label%3Dstatus%26up%3DOnline%26down%3DOffline%26colorUp%3D10b981%26colorDown%3Ddf484a&style=for-the-badge&logo=cloudflare&logoColor=white&labelColor=FAAD3F)](https://status.2jang.dev) 