### PR TITLE
sync: fallback to PAT_TOKEN secret when override-token is empty

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         default: false
       override-token:
-        description: '[Optional] Paste a PAT here. If left blank, PAT_TOKEN secret will be used (if set), otherwise GITHUB_TOKEN.'
+        description: '[Optional] Paste a PAT here. If left blank, PAT_TOKEN secret will be used (if set). Used to solve `refusing to allow a GitHub App to create or update workflow... `, more info at https://github.com/lyc8503/UptimeFlare/wiki/Synchronize-updates-from-upstream#upgrade-methods'
         required: false
 
 jobs:

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         default: false
       override-token:
-        description: '[Optional] Replace the default token with the supplied PAT. Used to resolve `refusing to allow a GitHub App to create or update workflow... `'
+        description: '[Optional] Paste a PAT here. If left blank, PAT_TOKEN secret will be used (if set), otherwise GITHUB_TOKEN.'
         required: false
 
 jobs:

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout target repo
         uses: actions/checkout@v3
         with:
-          token: ${{ inputs.override-token || secrets.GITHUB_TOKEN }}
+          token: ${{ inputs.override-token || secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Current config
         run: |


### PR DESCRIPTION
- Explain briefly:
  - UI input field doesn’t evaluate `${{ secrets.* }}`, users may paste it and it becomes a literal string.
  - Add fallback to `secrets.PAT_TOKEN` to make workflow_dispatch easier and safer.