### PR TITLE
Fix header margin & change error message wording

### DIFF
--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -1,6 +1,6 @@
 .header {
   height: rem(56px);
-  margin-bottom: rem(100px);
+  margin-bottom: auto;
   background-color: var(--mantine-color-body);
   border-bottom: rem(1px) solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }

--- a/worker/src/util.ts
+++ b/worker/src/util.ts
@@ -55,13 +55,13 @@ function formatStatusChangeNotification(
   } else if (timeNow == timeIncidentStart) {
     return `🔴 ${
       monitor.name
-    } is currently down. \nService is unavailable at ${timeNowFormatted}. \nIssue: ${
+    } is down. \nService became unavailable at ${timeNowFormatted}. \nIssue: ${
       reason || 'unspecified'
     }`
   } else {
     return `🔴 ${
       monitor.name
-    } is still down. \nService is unavailable since ${timeIncidentStartFormatted} (${downtimeDuration} minutes). \nIssue: ${
+    } is down. \nService unavailable since ${timeIncidentStartFormatted} (${downtimeDuration} minutes). \nIssue: ${
       reason || 'unspecified'
     }`
   }


### PR DESCRIPTION
There are two fixes in this PR. I appreciate they may be personal preferences so I'm happy to discuss them if you disagree. 

1. Change the header margin to auto - I find the header leaves too much white space on the page for me. I've tested on Firefox, Safari and Chrome, desktop and mobile. 
2. Change the error message wording - I use the gracePeriod for notifications and find it confusing to receive a message saying the monitor is "still down" for the first notification. I've adjusted the messages so they make more sense to me. 